### PR TITLE
Collapse whitespace before parsing numeric/temporal/enum values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.github.rzo1.org.metatype.sxc</groupId>
   <artifactId>sxc</artifactId>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
   <name>Simple XML Compiler</name>
 
   <packaging>pom</packaging>

--- a/sxc-core/pom.xml
+++ b/sxc-core/pom.xml
@@ -2,12 +2,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>sxc-core</artifactId>
   <name>SXC Core</name>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
 
   <parent>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
     <artifactId>sxc</artifactId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/sxc-jaxb-core/pom.xml
+++ b/sxc-jaxb-core/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>sxc</artifactId>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
 
   <groupId>io.github.rzo1.org.metatype.sxc</groupId>
   <artifactId>sxc-jaxb-core</artifactId>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
   <name>SXC JAXB :: Core</name>
 
   <packaging>jar</packaging>

--- a/sxc-jaxb-maven-plugin/pom.xml
+++ b/sxc-jaxb-maven-plugin/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>sxc</artifactId>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
 
   <groupId>io.github.rzo1.org.metatype.sxc</groupId>
   <artifactId>sxc-jaxb-maven-plugin</artifactId>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
   <name>SXC JAXB :: Maven Plugin</name>
 
   <packaging>maven-plugin</packaging>

--- a/sxc-jaxb/pom.xml
+++ b/sxc-jaxb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
     <artifactId>sxc</artifactId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>sxc-jaxb</artifactId>

--- a/sxc-jaxb/src/main/java/org/metatype/sxc/jaxb/ReaderIntrospector.java
+++ b/sxc-jaxb/src/main/java/org/metatype/sxc/jaxb/ReaderIntrospector.java
@@ -1041,53 +1041,61 @@ public class ReaderIntrospector {
     }
 
     private JExpression coerce(JAXBObjectBuilder builder, JVar xsrVar, JExpression stringValue, Class<?> destType) {
+        // Per the XML Schema spec the numeric, boolean and temporal builtin types use a
+        // whitespace="collapse" facet, so leading/trailing whitespace must be stripped
+        // before the lexical value is parsed. The primitive accessors (getElementAsInt(),
+        // ...) already trim; the wrapper/temporal branches below pass the raw text through
+        // and would otherwise fail on values such as "\n  30  \n". Collapse here so every
+        // numeric coercion behaves consistently. String stays untouched (it may legitimately
+        // carry significant whitespace and the element/attribute readers normalize it already).
+        final JExpression trimmed = destType.equals(String.class) ? stringValue : stringValue.invoke("trim");
         if (destType.isPrimitive()) {
             if (destType.equals(boolean.class)) {
-                return JExpr.lit("1").invoke("equals").arg(stringValue).cor(JExpr.lit("true").invoke("equals").arg(stringValue));
+                return JExpr.lit("1").invoke("equals").arg(trimmed).cor(JExpr.lit("true").invoke("equals").arg(trimmed));
             } else if (destType.equals(byte.class)) {
-                return context.toJClass(Byte.class).staticInvoke("parseByte").arg(stringValue);
+                return context.toJClass(Byte.class).staticInvoke("parseByte").arg(trimmed);
             } else if (destType.equals(short.class)) {
-                return context.toJClass(Short.class).staticInvoke("parseShort").arg(stringValue);
+                return context.toJClass(Short.class).staticInvoke("parseShort").arg(trimmed);
             } else if (destType.equals(int.class)) {
-                return context.toJClass(Integer.class).staticInvoke("parseInt").arg(stringValue);
+                return context.toJClass(Integer.class).staticInvoke("parseInt").arg(trimmed);
             } else if (destType.equals(long.class)) {
-                return context.toJClass(Long.class).staticInvoke("parseLong").arg(stringValue);
+                return context.toJClass(Long.class).staticInvoke("parseLong").arg(trimmed);
             } else if (destType.equals(float.class)) {
-                return context.toJClass(Float.class).staticInvoke("parseFloat").arg(stringValue);
+                return context.toJClass(Float.class).staticInvoke("parseFloat").arg(trimmed);
             } else if (destType.equals(double.class)) {
-                return context.toJClass(Double.class).staticInvoke("parseDouble").arg(stringValue);
+                return context.toJClass(Double.class).staticInvoke("parseDouble").arg(trimmed);
             }
         } else {
             if (destType.equals(String.class)) {
                 return stringValue;
             } else if (destType.equals(Boolean.class)) {
-                return JExpr.lit("1").invoke("equals").arg(stringValue).cor(JExpr.lit("true").invoke("equals").arg(stringValue));
+                return JExpr.lit("1").invoke("equals").arg(trimmed).cor(JExpr.lit("true").invoke("equals").arg(trimmed));
             } else if (destType.equals(Byte.class)) {
-                return context.toJClass(Byte.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Byte.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(Short.class)) {
-                return context.toJClass(Short.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Short.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(Integer.class)) {
-                return context.toJClass(Integer.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Integer.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(Long.class)) {
-                return context.toJClass(Long.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Long.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(Float.class)) {
-                return context.toJClass(Float.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Float.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(Double.class)) {
-                return context.toJClass(Double.class).staticInvoke("valueOf").arg(stringValue);
+                return context.toJClass(Double.class).staticInvoke("valueOf").arg(trimmed);
             } else if (destType.equals(XMLGregorianCalendar.class)) {
-                return builder.getDatatypeFactory().invoke("newXMLGregorianCalendar").arg(stringValue);
+                return builder.getDatatypeFactory().invoke("newXMLGregorianCalendar").arg(trimmed);
             } else if (destType.equals(Duration.class)) {
-                return builder.getDatatypeFactory().invoke("newDuration").arg(stringValue);
+                return builder.getDatatypeFactory().invoke("newDuration").arg(trimmed);
             } else if (destType.equals(BigDecimal.class)) {
-                return JExpr._new(context.toJClass(BigDecimal.class)).arg(stringValue);
+                return JExpr._new(context.toJClass(BigDecimal.class)).arg(trimmed);
             } else if (destType.equals(BigInteger.class)) {
-                return JExpr._new(context.toJClass(BigInteger.class)).arg(stringValue);
+                return JExpr._new(context.toJClass(BigInteger.class)).arg(trimmed);
             } else if (destType.isEnum()) {
                 JAXBEnumBuilder enumBuilder = enumBuilders.get(destType);
                 if (enumBuilder == null) {
                     throw new BuildException("Unknown enum type " + destType);
                 }
-                return invokeEnumParser(builder, xsrVar, enumBuilder, stringValue);
+                return invokeEnumParser(builder, xsrVar, enumBuilder, trimmed);
             }
         }
         throw new UnsupportedOperationException("Invalid type " + destType);

--- a/sxc-runtime/pom.xml
+++ b/sxc-runtime/pom.xml
@@ -2,12 +2,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>sxc-runtime</artifactId>
   <name>SXC Runtime</name>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
 
   <parent>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
     <artifactId>sxc</artifactId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/sxc-xpath/pom.xml
+++ b/sxc-xpath/pom.xml
@@ -2,12 +2,12 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>sxc-xpath</artifactId>
   <name>SXC XPath</name>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
 
   <parent>
     <groupId>io.github.rzo1.org.metatype.sxc</groupId>
     <artifactId>sxc</artifactId>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
   </parent>
 
   <dependencies>


### PR DESCRIPTION
The XML Schema builtin numeric, boolean, temporal and enumeration types use a whitespace="collapse" facet, so leading/trailing whitespace in the lexical value must be stripped before parsing. The primitive accessors (getElementAsInt(), ...) already trim, but the wrapper, temporal, decimal and enum coercions passed the raw element text straight into Integer.valueOf()/etc. As a result a perfectly valid descriptor such as

  <session-timeout>
      30
  </session-timeout>

failed with NumberFormatException. Trim the lexical value in coerce() for every type except String (which may legitimately carry significant whitespace and is already normalized by the element/attribute readers).

Also bump the project version to 0.10-SNAPSHOT.